### PR TITLE
changed custom _getline() to replicate standard library getline()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFILES=\
 		linked_helper.c\
 		tokenizer.c\
 		env_list.c\
-		extpwdwho.c\
+		builtin_funcs.c\
 		file_io.c
 
 

--- a/builtin_funcs.c
+++ b/builtin_funcs.c
@@ -26,5 +26,6 @@ int builtin_monalisa(char **commands)
 
 	if (!read_textfile("monalisa.txt", 3808))
 		write(STDOUT_FILENO, "Simplicity is the ultimate sophistication\n", 42);
+
 	return (0);
 }

--- a/header.h
+++ b/header.h
@@ -23,7 +23,7 @@
 extern char **environ;
 
 /* main functions */
-int _getline(char *buffer, unsigned int limit);
+ssize_t _getline(char **buffer, size_t *limit);
 void execute(char **commands, env_t *envlist);
 int execdavinci_builtins(char** commands);
 

--- a/memmalloc.c
+++ b/memmalloc.c
@@ -5,6 +5,7 @@
  * @ptr: pointer to reallocate memory
  * @old_size: size in bytes of allocated memory
  * @new_size: newsize of memory block in bytes
+ *
  * Return: void pointer to new allocation of memory
  */
 void *_realloc(void *ptr, unsigned int old_size, unsigned int new_size)
@@ -17,19 +18,25 @@ void *_realloc(void *ptr, unsigned int old_size, unsigned int new_size)
 		p = malloc(new_size);
 		return (p);
 	}
+
 	if (new_size == 0)
 	{
 		free(ptr);
 		return (NULL);
 	}
+
 	if (old_size == new_size)
 		return (ptr);
+
 	p = malloc(new_size);
 	if (p == NULL)
 		return (NULL);
+
 	for (i = 0; i < old_size && i < new_size; i++)
 		p[i] = ((char *)ptr)[i];
+
 	free(ptr);
+
 	return (p);
 }
 


### PR DESCRIPTION
modified custom _getline() to replicate standard library getline(), so a simple addition of or subtraction of __ can switch whether we use standard library or custom _getline().  Also updated syntax of some other functions to be more legible.