### PR TITLE
8 updates, including cleaning history, alias, worker, help, fixing all valgrind errors for all cases & betty holberton style for all files, fixed exit status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 David John Coleman II
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ EXENAME=hsh
 CFILES=\
 	aliasA.c\
 	aliasB.c\
+	buildarginv.c\
 	builtinA.c\
 	builtinB.c\
 	cd.c\

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ David John Coleman II - http://www.davidjohncoleman.com/
 
 ## License
 
-Public Domain, no copyright protection
+MIT License

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ our blog posting here:
 
 ## Usage
 
-**Compile**: `$ gcc -Wall -Werror -Wextra -pedantic -o hsh`
+**Compile**: `$ gcc -Wall -Werror -Wextra -pedantic *.c -o hsh`
 
 **Using Make**: `make all`
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ our blog posting here:
 
 ## Usage
 
-**Compile**: `$ gcc -Wall -Werror -Wextra -pedantic *.c -o hsh`
+### compile
 
-**Using Make**: `make all`
+```
+$ gcc -Wall -Werror -Wextra -pedantic *.c -o hsh
+```
+
+**Compile with Make**: `make all`
 
 ### executing the program
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ commands is designed to replicate output from the shell `sh` (dash) and some
 bash commands.  For more on the detailed functionality of our shell, please read
 our blog posting here:
 
+## Usage
+
+**Compile**: `$ gcc -Wall -Werror -Wextra -pedantic -o hsh`
+
+**Using Make**: `make all`
+
+### executing the program
+
+**interactive mode**: `$ ./hsh`
+
+**non-interactive mode**: `$ echo "ls -la" | ./hsh`
+
+### usage of arsine in interactive mode
+
+arsine functions just as any other shell.  Here is an example usage of the ls
+command with flags.  This command lists directory contents.
+
+```
+$ ls -la
+```
+
 ## File List
 
 See file `./FILE_LIST.md`
@@ -37,5 +58,3 @@ David John Coleman II - http://www.davidjohncoleman.com/
 ## License
 
 Public Domain, no copyright protection
-
-_special thanks to Walter White_

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ command with flags.  This command lists directory contents.
 $ ls -la
 ```
 
+## Testing
+
+To run tests on the custom shell follow the instructions in the custom shell
+checker in this repository: https://github.com/glyif/shellfish
+
 ## File List
 
 See file `./FILE_LIST.md`

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/aliasB.c
+++ b/aliasB.c
@@ -9,18 +9,10 @@
 int save_alias(arg_inventory_t *arginv)
 {
 	alias_t *tmp = arginv->alias;
-	char *name = "/.simple_shell_alias";
-	char *file, *home, *buffer;
-	env_t *home_node;
-	int lenhome, fd, lenname = _strlen(name);
+	char *file, *buffer;
+	int fd;
 
-	home_node = fetch_node(arginv->envlist, "HOME");
-	home = home_node->val;
-	lenhome = _strlen(home);
-
-	file = safe_malloc(sizeof(char) * (_strlen(home) + lenname + 1));
-	file = _strncat(file, home, lenhome);
-	file = _strncat(file, name, lenname);
+	file = arginv->alias_file;
 
 	fd = open(file, O_CREAT | O_WRONLY | O_TRUNC, 0666);
 	close(fd);
@@ -38,7 +30,6 @@ int save_alias(arg_inventory_t *arginv)
 		free(buffer);
 	}
 
-	free(file);
 	return (0);
 }
 
@@ -52,17 +43,11 @@ int load_alias(arg_inventory_t *arginv)
 {
 	ssize_t count;
 	size_t sz = BUFSIZE;
-	char *name = "/.simple_shell_alias";
-	char *file, *home, *buffer, *val;
-	env_t *home_node;
-	int lenhome, fd, lenname = _strlen(name);
+	char *file, *buffer, *val;
+	int fd;
 
-	home_node = fetch_node(arginv->envlist, "HOME");
-	home = home_node->val;
-	lenhome = _strlen(home);
-	file = safe_malloc(sizeof(char) * (_strlen(home) + lenname + 1));
-	file = _strncat(file, home, lenhome);
-	file = _strncat(file, name, lenname);
+	file = arginv->alias_file;
+
 	fd = open(file, O_RDONLY);
 	if (fd == -1)
 	{
@@ -82,7 +67,6 @@ int load_alias(arg_inventory_t *arginv)
 		*(val++) = '\0';
 		add_node_alias(&arginv->alias, buffer, val);
 	}
-	free(file);
 	free(buffer);
 	close(fd);
 	return (0);

--- a/buildarginv.c
+++ b/buildarginv.c
@@ -1,0 +1,58 @@
+#include "header.h"
+
+/**
+ * buildarginv - function to build a struct of the arguments inventory
+ * Return: pointer to arguments inventory struct
+ */
+arg_inventory_t *buildarginv(void)
+{
+	arg_inventory_t *arginv;
+
+	arginv = safe_malloc(sizeof(arg_inventory_t));
+	arginv->input_commands = safe_malloc(BUFSIZE * sizeof(char));
+	arginv->envlist = env_list();
+	arginv->buflimit = BUFSIZE;
+	arginv->st_mode = _filemode(STDIN_FILENO);
+	arginv->last_exit_code = 0;
+	arginv->last_bg_pid = -1;
+	arginv->n_bg_jobs = 0;
+	arginv->exit = 0;
+	arginv->exit_status = 0;
+
+	/* initialize history and history file */
+	arginv->history_file = set_name(arginv->envlist, "/.simple_shell_history");
+	arginv->history = history_list(arginv);
+
+	/* initialize the aliases and alias file */
+	arginv->alias_file = set_name(arginv->envlist, "/.simple_shell_alias");
+	arginv->alias = alias_list();
+	load_alias(arginv);
+
+	return (arginv);
+}
+
+/**
+ * set_name - appends home directory absolure path to filename
+ * @envlist: the linked list to environ variables
+ * @name: the name of the file to be written
+ *
+ * Return: char pointer to filename
+ */
+char *set_name(env_t *envlist, char *name)
+{
+	char *file, *home;
+	int lenhome, lenname;
+	env_t *home_node;
+
+	home_node = fetch_node(envlist, "HOME");
+	home = home_node->val;
+
+	lenhome = _strlen(home);
+	lenname = _strlen(name);
+
+	file = safe_malloc(sizeof(char) * (lenhome + lenname + 1));
+	file = _strncat(file, home, lenhome);
+	file = _strncat(file, name, lenname);
+
+	return (file);
+}

--- a/buildarginv.c
+++ b/buildarginv.c
@@ -13,7 +13,6 @@ arg_inventory_t *buildarginv(void)
 	arginv->envlist = env_list();
 	arginv->buflimit = BUFSIZE;
 	arginv->st_mode = _filemode(STDIN_FILENO);
-	arginv->last_exit_code = 0;
 	arginv->last_bg_pid = -1;
 	arginv->n_bg_jobs = 0;
 	arginv->exit = 0;

--- a/builtinA.c
+++ b/builtinA.c
@@ -116,7 +116,7 @@ int _arsine(arg_inventory_t *arginv)
 {
 	(void)arginv;
 
-	_puts("AsH3");
+	_puts("AsH3 special thanks to Walter White");
 
 	return (EXT_SUCCESS);
 }

--- a/builtinB.c
+++ b/builtinB.c
@@ -77,7 +77,7 @@ int the_help(arg_inventory_t *arginv)
 	char **commands;
 	int i = 0;
 	bins_t bins[] = {
-		{"exit", h_exit}, {"monalisa", h_monalisa}, {"env", h_env},
+		{"exit", h_exit}, {"arsine", h_arsine}, {"env", h_env},
 		{"setenv", h_setenv}, {"unsetenv", h_unsetenv},
 		{"history", h_history}, {"cd", h_cd}, {"alias", h_alias},
 		{"help", h_help},

--- a/builtinB.c
+++ b/builtinB.c
@@ -117,9 +117,9 @@ int the_exit(arg_inventory_t *arginv)
 	int es;
 
 	commands = (char **)arginv->commands;
-	if (commands[1] == '\0')
+	if (commands[1] == NULL)
 		arginv->exit = 1;
-	else if (commands[1][0] > 47 && commands[1][0] < 58)
+	else if (is_uint(commands[1]))
 	{
 		es = _atoi(commands[1]);
 		arginv->exit = 1;

--- a/builtinB.c
+++ b/builtinB.c
@@ -67,7 +67,7 @@ int _unalias(arg_inventory_t *arginv)
 }
 
 /**
- * the_help - prints mona lisa ascii art
+ * the_help - prints help commands info based on the other input argument
  * @arginv: arguments inventory
  *
  * Return: 0 on success

--- a/builtinB.c
+++ b/builtinB.c
@@ -75,7 +75,7 @@ int _unalias(arg_inventory_t *arginv)
 int the_help(arg_inventory_t *arginv)
 {
 	char **commands;
-	int i = 0;
+	int i = 0, retval = 127;
 	bins_t bins[] = {
 		{"exit", h_exit}, {"arsine", h_arsine}, {"env", h_env},
 		{"setenv", h_setenv}, {"unsetenv", h_unsetenv},
@@ -89,7 +89,7 @@ int the_help(arg_inventory_t *arginv)
 	if (commands[2] != NULL)
 	{
 		_perror("help: too many input commands.\n");
-		return (-1);
+		return (retval);
 	}
 
 	while (bins[i].function != NULL)
@@ -97,12 +97,13 @@ int the_help(arg_inventory_t *arginv)
 		if (_strcmp(bins[i].function, commands[1]) == 0)
 		{
 			bins[i].help();
+			retval = EXT_SUCCESS;
 			break;
 		}
 		i++;
 	}
 
-	return (EXT_SUCCESS);
+	return (retval);
 }
 
 /**

--- a/cd.c
+++ b/cd.c
@@ -65,7 +65,7 @@ int _cd(arg_inventory_t *arginv)
 		free(oldpwd);
 		free(pwd);
 		free(path);
-		return (-1);
+		return (2);
 	}
 	else
 	{

--- a/cd.c
+++ b/cd.c
@@ -9,40 +9,30 @@
  */
 char *yellow_brick_road(char **commands, env_t *envlist)
 {
-	env_t *fetched_home;
-	env_t *fetched_old;
+	env_t *fetched_home, *fetched_old;
 	int hyphen;
 	char *path;
 
-	path = malloc(1024);
+	path = safe_malloc(1024);
 
 	fetched_home = fetch_node(envlist, "HOME");
 	fetched_old = fetch_node(envlist, "OLDPWD");
 
 	if (commands[1] != NULL)
-	{
 		hyphen = _strncmp(commands[1], "-", 1);
-	}
 
 	if (commands[1] == NULL)
-	{
 		path = _strcpy(path, fetched_home->val);
-	}
 	else if (hyphen == 0)
-	{
 		path = _strcpy(path, fetched_old->val);
-	}
 	else if (commands[1][0] == '/')
-	{
 		path = _strcpy(path, commands[1]);
-	}
 	else
 	{
 		getcwd(path, 1024);
 		_strncat(path, "/", 1);
 		_strncat(path, commands[1], _strlen(commands[1]));
 	}
-
 
 	return (path);
 }
@@ -56,10 +46,7 @@ char *yellow_brick_road(char **commands, env_t *envlist)
  */
 int _cd(arg_inventory_t *arginv)
 {
-	char *path;
-	char *oldpwd;
-	char *pwd;
-	char **commands;
+	char *path, *oldpwd, *pwd, **commands;
 	int check;
 
 	oldpwd = safe_malloc(1024);
@@ -73,10 +60,11 @@ int _cd(arg_inventory_t *arginv)
 
 	check = chdir(path);
 
-	if (check < 0)
+	if (check == -1)
 	{
 		free(oldpwd);
 		free(pwd);
+		free(path);
 		return (-1);
 	}
 	else
@@ -85,6 +73,9 @@ int _cd(arg_inventory_t *arginv)
 		modify_node_env(&arginv->envlist, "PWD", pwd);
 		modify_node_env(&arginv->envlist, "OLDPWD", oldpwd);
 	}
+	free(oldpwd);
+	free(pwd);
+	free(path);
 
 	return (0);
 }

--- a/environB.c
+++ b/environB.c
@@ -12,9 +12,7 @@ env_t *add_node_env(env_t **head, char *var, char *val)
 {
 	env_t *new_node, *temp;
 
-	new_node = malloc(sizeof(env_t));
-	if (new_node == NULL)
-		return (NULL);
+	new_node = safe_malloc(sizeof(env_t));
 
 	new_node->var = _strdup(var);
 	new_node->val = _strdup(val);

--- a/executeA.c
+++ b/executeA.c
@@ -42,7 +42,7 @@ int exec_builtins(arg_inventory_t *arginv)
 	 *		close(old_stdout);
 	 *	}
 	 */
-
+	arginv->exit_status = retval;
 	return (retval);
 }
 

--- a/free.c
+++ b/free.c
@@ -18,6 +18,7 @@ int freeall(arg_inventory_t *arginv)
 		free(arginv->history_file);
 		free_environ(arginv->envlist);
 		free_alias(arginv->alias);
+		free(arginv->alias_file);
 		if (arginv->input_commands)
 			free(arginv->input_commands);
 		exit_status = arginv->exit_status;

--- a/free.c
+++ b/free.c
@@ -15,6 +15,7 @@ int freeall(arg_inventory_t *arginv)
 		save_alias(arginv);
 		file_history(arginv);
 		free_history(arginv->history);
+		free(arginv->history_file);
 		free_environ(arginv->envlist);
 		free_alias(arginv->alias);
 		if (arginv->input_commands)

--- a/getline.c
+++ b/getline.c
@@ -13,12 +13,6 @@ ssize_t _getline(char **buffer, size_t *limit)
 
 	count = _readline(STDIN_FILENO, buffer, limit);
 
-	if (count == 0)
-	{
-		free(*buffer);
-		exit(EXT_SUCCESS);
-	}
-
 	return (count);
 }
 

--- a/header.h
+++ b/header.h
@@ -106,6 +106,7 @@ char _isspace(char c);
 int _atoi(char *s);
 void _perror(char *string);
 void _memmove(void *dest, void *src, size_t n);
+int is_uint(char *num);
 
 /* ---------------custom malloc--------------- */
 char *mem_reset(char *str, int bytes);

--- a/header.h
+++ b/header.h
@@ -59,6 +59,7 @@ int is_redirection(int token_id);
 void init_tokens(tokens_t *tokens, int length);
 void delete_dups(tokens_t *tokens);
 void token_classify(tokens_t *tokens);
+void cleanup_tokens(tokens_t *tokens, unsigned int tokens_idx, char *data);
 
 /* -------custom environ------- */
 env_t *env_list(void);

--- a/header.h
+++ b/header.h
@@ -179,7 +179,7 @@ int free_alias(alias_t *head);
 
 /* ----help---- */
 void h_exit(void);
-void h_monalisa(void);
+void h_arsine(void);
 void h_env(void);
 void h_setenv(void);
 void h_unsetenv(void);

--- a/header.h
+++ b/header.h
@@ -40,9 +40,12 @@ extern char **environ;
 
 /* ---------------main--------------- */
 ssize_t _getline(char **buffer, size_t *limit);
-arg_inventory_t *buildarginv(void);
 int _filemode(int fd);
 ssize_t _readline(int fd, char **buffer, size_t *limit);
+
+/* --------- arguments inventory ---------- */
+arg_inventory_t *buildarginv(void);
+char *set_name(env_t *envlist, char *name);
 
 /* ---------------execute--------------- */
 pid_t execute(arg_inventory_t *arginv);

--- a/helpA.c
+++ b/helpA.c
@@ -5,9 +5,9 @@
  */
 void h_alias(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ alias [NAME]=[VALUE]");
+	_puts("\tDefine or display aliases, in the form:");
+	_puts("\n\talias [NAME]=[VALUE]");
 }
 
 /**
@@ -15,9 +15,8 @@ void h_alias(void)
  */
 void h_cd(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ cd");
+	_puts("\tChange the shell working directory.");
 }
 
 /**
@@ -25,9 +24,9 @@ void h_cd(void)
  */
 void h_env(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ env");
+	_puts("\tDisplay all environmental variables, in the form:");
+	_puts("\n\t[NAME]=[VALUE]");
 }
 
 /**
@@ -35,9 +34,8 @@ void h_env(void)
  */
 void h_exit(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ exit");
+	_puts("\tExit the shell.");
 }
 
 /**
@@ -45,7 +43,6 @@ void h_exit(void)
  */
 void h_help(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ help [command]");
+	_puts("\tDisplay information about builtin commands.");
 }

--- a/helpB.c
+++ b/helpB.c
@@ -5,18 +5,16 @@
  */
 void h_history(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ history");
+	_puts("Display the history list.");
 }
 
 /**
- * h_monalisa - help function to explain how the associated function works
+ * h_arsine - help function to explain how the associated function works
  */
-void h_monalisa(void)
-{	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+void h_arsine(void)
+{	_puts("\nUsage: $ arsine");
+	_puts("\t shows chemical formula of shell");
 }
 
 /**
@@ -24,9 +22,8 @@ void h_monalisa(void)
  */
 void h_setenv(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ setenv [NAME] [VALUE]");
+	_puts("\tSets a new environmental variable");
 }
 
 /**
@@ -34,7 +31,6 @@ void h_setenv(void)
  */
 void h_unsetenv(void)
 {
-	_puts("this is a help file:");
-	_puts("first: goolge your question");
-	_puts("second: contact developers for help");
+	_puts("\nUsage: $ unsetenv [NAME]");
+	_puts("\tUnsets a saved environmental variable");
 }

--- a/history.c
+++ b/history.c
@@ -9,23 +9,16 @@
 history_t *history_list(arg_inventory_t *arginv)
 {
 	history_t *head;
-	char *name = "/.simple_shell_history", *file, *home, *buffer;
-	env_t *home_node;
-	int lenhome, fd, lenname = _strlen(name);
+	char *file, *buffer;
+	int fd;
 	size_t iterations = 1, charcount = 0, i = 0;
 
 	head = NULL;
-	home_node = fetch_node(arginv->envlist, "HOME");
-	home = home_node->val;
-	lenhome = _strlen(home);
-	file = safe_malloc(sizeof(char) * (_strlen(home) + lenname + 1));
-	file = _strncat(file, home, lenhome);
-	file = _strncat(file, name, lenname);
+	file = arginv->history_file;
 	fd = open(file, O_RDONLY);
-   	buffer = safe_malloc(sizeof(char) * BUFSIZE);
+	buffer = safe_malloc(sizeof(char) * BUFSIZE);
 	if (fd == -1 || buffer == NULL)
 	{
-		free(file);
 		free(buffer);
 		return (head);
 	}
@@ -46,11 +39,9 @@ history_t *history_list(arg_inventory_t *arginv)
 	close(fd);
 	if (charcount == 0)
 	{
-		free(file);
 		free(buffer);
 		return (head);
 	}
-	free(file);
 	head = init_history(head, buffer);
 	return (head);
 }
@@ -122,7 +113,7 @@ history_t *add_node_history(history_t **head, char *command)
 			free_history(*head);
 			*head = new_node;
 			return (new_node);
-		 }
+		}
 		new_node->number = i;
 		temp->next = new_node;
 	}
@@ -138,24 +129,12 @@ history_t *add_node_history(history_t **head, char *command)
  */
 int file_history(arg_inventory_t *arginv)
 {
-	char *name = "/.simple_shell_history";
-	char *file, *history_text, *home;
-	env_t *home_node;
-	int lenhome, lenname = _strlen(name);
-
-	home_node = fetch_node(arginv->envlist, "HOME");
-	home = home_node->val;
-	lenhome = _strlen(home);
-
-	file = safe_malloc(sizeof(char) * (_strlen(home) + lenname + 1));
-	file = _strncat(file, home, lenhome);
-	file = _strncat(file, name, lenname);
+	char *history_text;
 
 	history_text = history_to_string(arginv->history);
-	trunc_text_to_file(file, history_text);
+	trunc_text_to_file(arginv->history_file, history_text);
 
 	free(history_text);
-	free(file);
 
 	return (0);
 }

--- a/main.c
+++ b/main.c
@@ -1,44 +1,6 @@
 #include "header.h"
 
 /**
- * buildarginv - function to build a struct of the arguments inventory
- * Return: pointer to arguments inventory struct
- */
-arg_inventory_t *buildarginv(void)
-{
-	arg_inventory_t *arginv;
-	char *file, *home, *name = "/.simple_shell_history";
-	int lenhome, lenname;
-	env_t *home_node;
-
-	arginv = safe_malloc(sizeof(arg_inventory_t));
-	arginv->input_commands = safe_malloc(BUFSIZE * sizeof(char));
-	arginv->envlist = env_list();
-	arginv->alias = alias_list();
-	arginv->buflimit = BUFSIZE;
-	arginv->st_mode = _filemode(STDIN_FILENO);
-	arginv->last_exit_code = 0;
-	arginv->last_bg_pid = -1;
-	arginv->n_bg_jobs = 0;
-	arginv->exit = 0;
-	arginv->exit_status = 0;
-
-	/* initialize history and history file */
-	home_node = fetch_node(arginv->envlist, "HOME");
-	home = home_node->val;
-	lenhome = _strlen(home), lenname = _strlen(name);
-	file = safe_malloc(sizeof(char) * (lenhome + lenname + 1));
-	file = _strncat(file, home, lenhome);
-	file = _strncat(file, name, lenname);
-	arginv->history_file = file;
-	arginv->history = history_list(arginv);
-
-	load_alias(arginv);
-
-	return (arginv);
-}
-
-/**
  * sig_handler - handles user input of ^C with the following
  * @sig: integer value of signal to change, will be SIGINT = ^C
  *

--- a/main.c
+++ b/main.c
@@ -7,11 +7,13 @@
 arg_inventory_t *buildarginv(void)
 {
 	arg_inventory_t *arginv;
+	char *file, *home, *name = "/.simple_shell_history";
+	int lenhome, lenname;
+	env_t *home_node;
 
 	arginv = safe_malloc(sizeof(arg_inventory_t));
 	arginv->input_commands = safe_malloc(BUFSIZE * sizeof(char));
 	arginv->envlist = env_list();
-	arginv->history = history_list(arginv);
 	arginv->alias = alias_list();
 	arginv->buflimit = BUFSIZE;
 	arginv->st_mode = _filemode(STDIN_FILENO);
@@ -20,11 +22,16 @@ arg_inventory_t *buildarginv(void)
 	arginv->n_bg_jobs = 0;
 	arginv->exit = 0;
 	arginv->exit_status = 0;
-	if (arginv->envlist == NULL)
-	{
-		_perror("No Memory\n");
-		write(STDOUT_FILENO, "insufficient memory", 19);
-	}
+
+	/* initialize history and history file */
+	home_node = fetch_node(arginv->envlist, "HOME");
+	home = home_node->val;
+	lenhome = _strlen(home), lenname = _strlen(name);
+	file = safe_malloc(sizeof(char) * (lenhome + lenname + 1));
+	file = _strncat(file, home, lenhome);
+	file = _strncat(file, name, lenname);
+	arginv->history_file = file;
+	arginv->history = history_list(arginv);
 
 	load_alias(arginv);
 

--- a/man_1_simple_shell
+++ b/man_1_simple_shell
@@ -69,7 +69,7 @@ the arsine executable file ('hsh').  This is an example:
 .B $ echo 'ls' | ./hsh
 .P
 .RE
-Commands may also be input into daVinci through a file containing commands:
+Commands may also be input into arsine through a file containing commands:
 .P
 .RS
 .B $ cat aFile | ./hsh
@@ -81,13 +81,13 @@ Commands may also be input into daVinci through a file containing commands:
 .SH OPTIONS
 
 arsine does not take any options but does utilize the variable extern char \
-**environ.  This is currently part of the future goals of daVinci
+**environ.  This is currently part of the future goals of arsine
 
 
 .SS BUILT-IN COMMANDS
 
 .RS
-This secion has information on the included builtin commands with daVinci
+This secion has information on the included builtin commands with arsine
 
 .Bl -tag -width "PAGEIN" -compact -offset indent
 
@@ -146,5 +146,3 @@ none known.  arsine does not currently replicate these tasks:
 Bobby Yang <122@holberton.com>
 
 David John Coleman II <lcsw@davidjohncoleman.com>
-
-special thanks to: walter white

--- a/parseB.c
+++ b/parseB.c
@@ -35,7 +35,7 @@ void bash_replace(arg_inventory_t *arginv, int index)
 					break;
 				case '?':
 					replace_str((char **)&t.tokens[index].str,
-						int_to_str(arginv->last_exit_code), j,
+						int_to_str(arginv->exit_status), j,
 						j + 1, 1);
 					break;
 				case '!':

--- a/parseB.c
+++ b/parseB.c
@@ -1,10 +1,16 @@
 #include "header.h"
 
+/**
+ * _getpid - gets the pid and starts a new child precess
+ *
+ * Return: returns the pid of new child process
+ */
 int _getpid(void)
 {
 	int pid;
 
 	pid = fork();
+
 	if (pid > 0)
 		return (pid);
 	else
@@ -26,7 +32,6 @@ void bash_replace(arg_inventory_t *arginv, int index)
 		if (t.tokens[index].str[j] == '$' && t.tokens[index].str[j + 1] != '\0')
 			switch (t.tokens[index].str[j + 1])
 			{
-				
 				case '$':
 					replace_str((char **)&t.tokens[index].str,
 						int_to_str(_getpid()), j, j + 1, 1);

--- a/parseB.c
+++ b/parseB.c
@@ -11,10 +11,7 @@ int _getpid(void)
 
 	pid = fork();
 
-	if (pid > 0)
-		return (pid);
-	else
-		return (pid);
+	return (pid);
 }
 
 /**

--- a/stdlib_funcs.c
+++ b/stdlib_funcs.c
@@ -85,3 +85,25 @@ void _memmove(void *dest, void *src, size_t n)
 		copy_dest[i] = temp[i];
 	free(temp);
 }
+
+/**
+ * is_uint - checks if input string is unsigned int
+ * @number: the input number
+ * Return: TRUE or FALSE
+ */
+int is_uint(char *num)
+{
+	int i = 0;
+
+	while (num[i])
+	{
+		if (num[i] > 47 && num[i] < 58)
+			i++;
+		else if (num[i] == 45 && i == 0)
+			return (FALSE);
+		else
+			return (FALSE);
+	}
+
+	return (TRUE);
+}

--- a/stdlib_funcs.c
+++ b/stdlib_funcs.c
@@ -88,7 +88,7 @@ void _memmove(void *dest, void *src, size_t n)
 
 /**
  * is_uint - checks if input string is unsigned int
- * @number: the input number
+ * @num: the input number
  * Return: TRUE or FALSE
  */
 int is_uint(char *num)

--- a/structs.h
+++ b/structs.h
@@ -152,6 +152,7 @@ typedef struct alias
  * @commands: double pointer to commands list
  * @st_mode: st_mode either FIFO or terminal
  * @history: linked list of history
+ * @history_file: the history file to story history in
  * @alias: linked list of aliases
  * @tokens: tokens list
  * @parser: a parse
@@ -174,6 +175,7 @@ typedef struct arg_inventory
 	size_t buflimit;
 	int st_mode;
 	history_t *history;
+	char *history_file;
 	alias_t *alias;
 	tokens_t   tokens;
 	parser_t   parser;

--- a/structs.h
+++ b/structs.h
@@ -152,7 +152,8 @@ typedef struct alias
  * @commands: double pointer to commands list
  * @st_mode: st_mode either FIFO or terminal
  * @history: linked list of history
- * @history_file: the history file to story history in
+ * @history_file: the history file to store command history
+ * @alias_file: the aliases file to store aliases
  * @alias: linked list of aliases
  * @tokens: tokens list
  * @parser: a parse
@@ -177,8 +178,9 @@ typedef struct arg_inventory
 	history_t *history;
 	char *history_file;
 	alias_t *alias;
-	tokens_t   tokens;
-	parser_t   parser;
+	char *alias_file;
+	tokens_t tokens;
+	parser_t parser;
 	pipeline_t pipeline;
 	int n_bg_jobs;
 	int pipein;

--- a/structs.h
+++ b/structs.h
@@ -163,7 +163,6 @@ typedef struct alias
  * @pipeout: pipeout variable
  * @io_redir: io redirection
  * @filename: the filename
- * @last_exit_code: last exit code
  * @last_bg_pid: last pid
  * @exit: indicator to exit or not
  * @exit_status: the exit status
@@ -189,7 +188,6 @@ typedef struct arg_inventory
 	int io_redir;
 	char *filename;
 
-	int last_exit_code;
 	pid_t last_bg_pid;
 
 	int exit;

--- a/tokenize.c
+++ b/tokenize.c
@@ -8,7 +8,7 @@
 void tokenize(tokens_t *tokens, const char *string)
 {
 	unsigned int l, string_idx, data_idx, tokens_idx;
-	unsigned int skip_next, skip_quote, is_token, i;
+	unsigned int skip_next, skip_quote, is_token;
 	char *data, symbol;
 
 	l = (_strlen(string) == 0 ? 1 : _strlen(string));
@@ -34,7 +34,7 @@ void tokenize(tokens_t *tokens, const char *string)
 			data[data_idx++] = ';', data[data_idx++] = '\0', is_token = 0;
 			continue;
 		}
-		if ((symbol == '\"') && !skip_next)
+		if ((symbol == '\"' || symbol == '\'') && !skip_next)
 		{
 			skip_quote = !skip_quote;
 			continue;
@@ -46,10 +46,24 @@ void tokenize(tokens_t *tokens, const char *string)
 		}
 		skip_next = 0, data[data_idx++] = symbol;
 	}
-	data[data_idx] = '\0';
+	cleanup_tokens(tokens, tokens_idx, data);
+}
+
+/**
+ * cleanup_tokens - cleans up tokeniz functions
+ * @tokens: the tokenized tokens variable
+ * @tokens_idx: the index referring to the tokens
+ * @data: pointer used to store the data in tokens, only used in this
+ * function to free the memory there
+ */
+void cleanup_tokens(tokens_t *tokens, unsigned int tokens_idx, char *data)
+{
+	unsigned int i;
+
 	tokens->tokensN = tokens_idx;
 	token_classify(tokens);
 	delete_dups(tokens);
+
 	if (tokens->tokensN)
 	{
 		if (tokens->tokens[tokens->tokensN - 1].id == TOKEN_SEMICOLON)

--- a/worker.c
+++ b/worker.c
@@ -58,7 +58,7 @@ pid_t worker_execute_core(arg_inventory_t *arginv)
 pid_t worker_execute_tree(arg_inventory_t *arginv, ptree_t *ptree,
 						  unsigned int depth)
 {
-	int status, id, execute;
+	int status = NULL, id, execute = 1;
 	pid_t last_pid = -1;
 
 	if (!ptree)
@@ -90,7 +90,6 @@ pid_t worker_execute_tree(arg_inventory_t *arginv, ptree_t *ptree,
 			status = 0;
 		}
 		arginv->last_exit_code = status;
-		execute = 1;
 		if ((id == TOKEN_AND && status) || (id == TOKEN_OR && !status))
 			execute = 0;
 		if (execute)

--- a/worker.c
+++ b/worker.c
@@ -126,7 +126,15 @@ int worker_execute(arg_inventory_t *arginv)
 			status = 0;
 		}
 		arginv->last_exit_code = status;
-		arginv->exit_status = status ? 127 : status;
+		switch (status)
+		{
+		case 1:
+			arginv->exit_status = 127;
+			break;
+		default:
+			arginv->exit_status = status;
+			break;
+		}
 	}
 	return (0);
 }

--- a/worker.c
+++ b/worker.c
@@ -11,8 +11,10 @@ pid_t worker_execute_core(arg_inventory_t *arginv)
 	unsigned int i;
 	/* int p[2]; Set of pipes' descriptors */
 	ptree_t *ptree;
-	/* int fd_input = 0; Input file descriptor; soon to be changed with
-						 something if there is < command somewhere */
+	/**
+	 * int fd_input = 0; Input file descriptor; soon to be changed with
+	 * something if there is < command somewhere
+	 */
 
 	for (i = 0; i < arginv->pipeline.processesN; i++)
 	{
@@ -23,26 +25,27 @@ pid_t worker_execute_core(arg_inventory_t *arginv)
 
 		/* pipe(p); Create the two-way pipe */
 
-		/*
-		arginv->pipein = fd_input;
-		arginv->pipeout = (i + 1 < arginv->pipeline.processesN) ? p[1] : 0;
-
-		if (arginv->pipeline.processes[i].io_redir)
-		{
-			arginv->filename = arginv->pipeline.processes[i].filename;
-			arginv->io_redir = arginv->pipeline.processes[i].io_redir;
-		}
-		else
-		{
-			arginv->filename = NULL;
-			arginv->io_redir = 0;
-		}
-		*/
+		/**
+		 * arginv->pipein = fd_input;
+		 * arginv->pipeout = (i + 1 < arginv->pipeline.processesN) ? p[1] : 0;
+		 *
+		 *		if (arginv->pipeline.processes[i].io_redir)
+		 *		{
+		 *			arginv->filename = arginv->pipeline.processes[i].filename;
+		 *			arginv->io_redir = arginv->pipeline.processes[i].io_redir;
+		 *		}
+		 *		else
+		 *		{
+		 *			arginv->filename = NULL;
+		 *			arginv->io_redir = 0;
+		 *		}
+		 */
 
 		arginv->pipeline.processes[i].pid = execute(arginv);
-		/*
-		close(p[1]); */ /*Close non-needed descriptor */
-		/* fd_input = p[0]; */ /* The input should be saved for the next comman */
+		/**
+		 * close(p[1]); Close non-needed descriptor
+		 * fd_input = p[0];  The input should be saved for the next comman
+		 */
 	}
 
 	return (arginv->pipeline.processes[arginv->pipeline.processesN - 1].pid);

--- a/worker.c
+++ b/worker.c
@@ -91,7 +91,7 @@ pid_t worker_execute_tree(arg_inventory_t *arginv, ptree_t *ptree,
 		}
 		arginv->last_exit_code = status;
 		execute = 1;
-		if ((id == TOKEN_AND || id == TOKEN_OR)	&& status != EXIT_SUCCESS)
+		if ((id == TOKEN_AND && status) || (id == TOKEN_OR && !status))
 			execute = 0;
 		if (execute)
 			last_pid = worker_execute_tree(arginv, ptree->right, depth + 1);

--- a/worker.c
+++ b/worker.c
@@ -78,10 +78,8 @@ pid_t worker_execute_tree(arg_inventory_t *arginv, ptree_t *ptree,
 		{ /* wait for the child */
 			waitpid(last_pid, &status, 0);
 
-			if (WIFEXITED(status))
-				status = WEXITSTATUS(status);
-			else
-				status = 1;
+			status = WEXITSTATUS(status);
+			arginv->exit_status = status ? 127 : status;
 		}
 		else
 		{
@@ -119,8 +117,7 @@ int worker_execute(arg_inventory_t *arginv)
 		{
 			status = 1;
 			waitpid(last_pid, &status, 0);
-			if (WIFEXITED(status))
-				status = WEXITSTATUS(status);
+			status = WEXITSTATUS(status);
 		}
 		else
 		{
@@ -129,6 +126,7 @@ int worker_execute(arg_inventory_t *arginv)
 			status = 0;
 		}
 		arginv->last_exit_code = status;
+		arginv->exit_status = status ? 127 : status;
 	}
 	return (0);
 }


### PR DESCRIPTION
- placed ending functionality from the `tokenize()` function to a new `cleanup()` function in the `tokenize.c` file.

- combined all the if statements in **worker.c**, updated uninitialized value error in the worker.c.  Error occurred with input command of: `echo "ls"; echo 'hi'; pwd; ls -la; env; env; history; # echo 'ls'`, ran tests, shell still compiles and has all same functionality.
 
- Used `safe_malloc()` instead of all instances of `malloc()` to initialize all memory to '\0'.
 
- Cleaned up all **history** and **alias** functions to set an argument in the `arginv` that has the filename including path of the stored history.
 
- Added Actual help commands for all built-in functions
 
- Cleaned up README with usage, and removed W.W. reference
 
- **All code passes betty holberton style now**

-**fixed exit status** cleaned up exit status and made exit status always return the status from child process, removed unused if statement in get_pid(), updated getline to not exit with no input, and instead exit with the standard exit